### PR TITLE
Modified binder launch scripts to launch tensorboard through jupyter server proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # handson_pytorch
 
-[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/PyDataOsaka/handson_pytorch/master?urlpath=lab/tree/index.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/wrist/handson_pytorch/master?urlpath=lab/tree/index.ipynb)
+[![Binder](https://mybinder.org/badge_logo.svg)](https://mybinder.org/v2/gh/wrist/handson_pytorch/master?urlpath=/proxy/6006/) (Tensorboard)
 
 pytorchのハンズオンです

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,1 +1,3 @@
 jupyter labextension install @jupyterlab/toc
+mv tensorboard_server_extension.py ${NB_PYTHON_PREFIX}/lib/python*/site-packages/
+jupyter serverextension enable --sys-prefix tensorboard_server_extension

--- a/binder/requirements.txt
+++ b/binder/requirements.txt
@@ -1,3 +1,4 @@
 torch
 torchvision
-
+tensorboard
+jupyter-server-proxy

--- a/tensorboard_server_extension.py
+++ b/tensorboard_server_extension.py
@@ -1,0 +1,4 @@
+from subprocess import Popen
+
+def load_jupyter_server_extension(nbapp):
+    Popen(["tensorboard", "--logdir", "logs", "--port", "6006"])


### PR DESCRIPTION
* Added `tensorboard` and `jupyter-server-proxy` to `requirements.txt`
* Added server extension script to launch tensorboard on binder start-up
    * enabled from `binder/postBuild`
* Modified README.md
    * added a link to launch binder with opening tensorboard(`/proxy/6006`)